### PR TITLE
Fix check for SystemInfo

### DIFF
--- a/lmcloud/lm_machine.py
+++ b/lmcloud/lm_machine.py
@@ -505,7 +505,7 @@ class LaMarzoccoMachine(LaMarzoccoDevice):
                 )
                 property_updated = True
 
-            elif "SystemInfo" in message:
+            elif "SystemInfo" in msg:
                 self._system_info = json.loads(msg["SystemInfo"])
                 property_updated = True
 


### PR DESCRIPTION
The check for SystemInfo was looking in the original list and not in each element/dict.  Otherwise, I was still getting these logs in HA:

```
2024-03-24 12:31:01.222 WARNING (MainThread) [lmcloud.lm_machine] Unknown websocket message received
2024-03-24 12:31:01.222 WARNING (MainThread) [lmcloud.lm_machine] Message: [{"SystemInfo":"{\"network_interfaces\":[{\"name\":\"wlan0\",\"address\":\"192.168.1.215\",\"mac\":\"c8:2b:96:90:7b:88\",\"auth\":\"WPA2_PSK\",\"channel\":6,\"rssi\":-63}],\"system_ram\":[{\"name\":\"internal\",\"free\":62999,\"allocated\":236792},{\"name\":\"external\",\"free\":4048159,\"allocated\":385800}],\"cpu\":{\"cpu0\":0,\"cpu1\":0},\"connections\":{\"ws\":1095,\"ble\":2,\"mqtt\":2,\"wifi\":1},\"up_time\":432381,\"curr_time\":\"2024-03-24 12:31:00\",\"boot_reason\":\"ESP_RST_SW\",\"boot_count\":0,\"fs\":{\"total\":4096000,\"used\":61440,\"files\":[{\"path\":\"/storage/auth\",\"size\":175},{\"path\":\"/storage/cert.crt\",\"size\":1224},{\"path\":\"/storage/log.txt\",\"size\":0},{\"path\":\"/storage/machine.bin\",\"size\":44096},{\"path\":\"/storage/private.key\",\"size\":1675}]},\"zone\":\"America/Los_Angeles\"}"}]
```